### PR TITLE
Fix for bug #12.

### DIFF
--- a/Adafruit_SSD1351.h
+++ b/Adafruit_SSD1351.h
@@ -1,18 +1,18 @@
-/*************************************************** 
-  This is a library for the 1.5" & 1.27" 16-bit Color OLEDs 
+/***************************************************
+  This is a library for the 1.5" & 1.27" 16-bit Color OLEDs
   with SSD1331 driver chip
 
   Pick one up today in the adafruit shop!
   ------> http://www.adafruit.com/products/1431
   ------> http://www.adafruit.com/products/1673
 
-  These displays use SPI to communicate, 4 or 5 pins are required to  
+  These displays use SPI to communicate, 4 or 5 pins are required to
   interface
-  Adafruit invests time and resources providing this open source code, 
-  please support Adafruit and open-source hardware by purchasing 
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
 
-  Written by Limor Fried/Ladyada for Adafruit Industries.  
+  Written by Limor Fried/Ladyada for Adafruit Industries.
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
@@ -30,6 +30,9 @@
 #ifdef __SAM3X8E__
     typedef volatile RwReg PortReg;
     typedef uint32_t PortMask;
+#elif defined _VARIANT_ARDUINO_ZERO_
+    typedef volatile uint32_t PortReg;
+    typedef volatile uint32_t PortMask;
 #else
     typedef volatile uint8_t PortReg;
     typedef uint8_t PortMask;


### PR DESCRIPTION
In the Adafruit_SSD1351.h, I added a conditional to the macro that is used to define the PortReq and Port Mask to handle the Arduino Zero. I found that the Zero port methods were returning a uint32_t instead of a uint8_t. 
- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.
- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.
# Issue addressed:

This is to fix: #12, which is to address the library not working for the Ardino
Zero boards. The issue seems to be that for this board, using IDE 1.6.9,
the ports now return a uint32_t instead f a uint8_t.
## To address this issue

I added a marco case to define the types of the
PortReg and Port Mask to be uint32_t. I chose a macro that was clearly
defined in the variant.h of the zero.
# Scope of change:

In the Adafruit_SSD1351.h, I added a conditional to the macro that is used to define the PortReq and Port Mask to handle the Arduino Zero. I found that the Zero port methods were returning a uint32_t instead of a uint8_t. 
# Tests performed:

I used the pixel_demo, which I found at: http://rabidprototypes.com/wp-content/uploads/2016/03/pixel_demo.zip.  Before my change, I was unable to compile, due to the errors defined in the bug. Once I made these changes, the code compiled and the sketch was uploaded and ran successfully. Since this code is exactly what is installed with the board (I was using the Rabid Prototypes Pixel, which is based off of a Zero: https://www.kickstarter.com/projects/rabidprototypes/pixel-the-arduino-compatible-smart-display/comments) I modified the code by changing the text and color. 
# Limitations:

The only limitation is that I only made the change to handle the Zero. There maybe other boards that will have the same issue. In which case the block may be improved with a better check. 
