### PR TITLE
Added Arduino Primo support

### DIFF
--- a/Adafruit_SSD1351.cpp
+++ b/Adafruit_SSD1351.cpp
@@ -24,6 +24,8 @@
   #include <avr/pgmspace.h>
 #elif defined(ESP8266)
   #include <pgmspace.h>
+#elif defined(NRF51) || defined(NRF52) || defined(__RFduino__) || defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+  #include <avr/pgmspace.h>
 #endif
 #include "pins_arduino.h"
 #include "wiring_private.h"
@@ -46,11 +48,13 @@ inline void Adafruit_SSD1351::spiwrite(uint8_t c) {
 	delayMicroseconds(1);
         return;
     }
-    
+
+	#if !defined(NRF51) && !defined(NRF52) && !defined(__RFduino__) && !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
+
     int8_t i;
     
     *sclkport |= sclkpinmask;
-    
+
     for (i=7; i>=0; i--) {
         *sclkport &= ~sclkpinmask;
         //SCLK_PORT &= ~_BV(SCLK);
@@ -68,36 +72,57 @@ inline void Adafruit_SSD1351::spiwrite(uint8_t c) {
         *sclkport |= sclkpinmask;
         //SCLK_PORT |= _BV(SCLK);
     }
+	#endif
 }
 
 
 void Adafruit_SSD1351::writeCommand(uint8_t c) {
-    *rsport &= ~ rspinmask;
-    //digitalWrite(_rs, LOW);
+	#if defined(NRF51) || defined(NRF52) || defined(__RFduino__) || defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+	digitalWrite(_rs, LOW);
+	#else
+	*rsport &= ~ rspinmask;
+	#endif
     
-    *csport &= ~ cspinmask;
+	#if defined(NRF51) || defined(NRF52) || defined(__RFduino__) || defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+	digitalWrite(_cs, LOW);
+	#else
+	*csport &= ~ cspinmask;
+	#endif
     //digitalWrite(_cs, LOW);
     
     //Serial.print("C ");
     spiwrite(c);
     
-    *csport |= cspinmask;
-    //digitalWrite(_cs, HIGH);
+	#if defined(NRF51) || defined(NRF52) || defined(__RFduino__) || defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+	digitalWrite(_cs, HIGH);
+	#else
+	*csport |= cspinmask;
+	#endif
 }
 
 
 void Adafruit_SSD1351::writeData(uint8_t c) {
+	#if defined(NRF51) || defined(NRF52) || defined(__RFduino__) || defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+    digitalWrite(_rs, HIGH);
+	#else
     *rsport |= rspinmask;
-    //digitalWrite(_rs, HIGH);
-    
+    #endif
+	
+	#if defined(NRF51) || defined(NRF52) || defined(__RFduino__) || defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+	digitalWrite(_cs, LOW);
+	#else
     *csport &= ~ cspinmask;
-    //digitalWrite(_cs, LOW);
+	#endif
+
     
 //    Serial.print("D ");
     spiwrite(c);
     
+	#if defined(NRF51) || defined(NRF52) || defined(__RFduino__) || defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+	digitalWrite(_cs, HIGH);
+	#else
     *csport |= cspinmask;
-    //digitalWrite(_cs, HIGH);
+	#endif
 } 
 
 /***********************************/
@@ -336,13 +361,22 @@ void Adafruit_SSD1351::drawPixel(int16_t x, int16_t y, uint16_t color)
   goTo(x, y);
   
   // setup for data
-  *rsport |= rspinmask;
-  *csport &= ~ cspinmask;
-  
+	#if defined(NRF51) || defined(NRF52) || defined(__RFduino__) || defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+	digitalWrite(_cs, LOW);
+	digitalWrite(_rs, HIGH);
+	#else
+	*csport &= ~ cspinmask;
+	*rsport |= rspinmask;
+	#endif
+	  
   spiwrite(color >> 8);    
   spiwrite(color);
   
-  *csport |= cspinmask;
+  	#if defined(NRF51) || defined(NRF52) || defined(__RFduino__) || defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+	digitalWrite(_cs, HIGH);
+	#else
+	*csport |= cspinmask;
+	#endif
 }
 
 void Adafruit_SSD1351::begin(void) {
@@ -454,7 +488,7 @@ void  Adafruit_SSD1351::invert(boolean v) {
  }
 
 /********************************* low level pin initialization */
-
+#if !defined(NRF51) && !defined(NRF52) && !defined(__RFduino__) && !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
 Adafruit_SSD1351::Adafruit_SSD1351(uint8_t cs, uint8_t rs, uint8_t sid, uint8_t sclk, uint8_t rst) : Adafruit_GFX(SSD1351WIDTH, SSD1351HEIGHT) {
     _cs = cs;
     _rs = rs;
@@ -475,6 +509,7 @@ Adafruit_SSD1351::Adafruit_SSD1351(uint8_t cs, uint8_t rs, uint8_t sid, uint8_t 
     sclkpinmask   = digitalPinToBitMask(sclk);
 
 }
+#endif
 
 Adafruit_SSD1351::Adafruit_SSD1351(uint8_t cs, uint8_t rs,  uint8_t rst) : Adafruit_GFX(SSD1351WIDTH, SSD1351HEIGHT) {
     _cs = cs;
@@ -482,12 +517,12 @@ Adafruit_SSD1351::Adafruit_SSD1351(uint8_t cs, uint8_t rs,  uint8_t rst) : Adafr
     _sid = 0;
     _sclk = 0;
     _rst = rst;
-
+#if !defined(NRF51) && !defined(NRF52) && !defined(__RFduino__) && !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
     csport      = portOutputRegister(digitalPinToPort(cs));
     cspinmask   = digitalPinToBitMask(cs);
-    
     rsport      = portOutputRegister(digitalPinToPort(rs));
     rspinmask   = digitalPinToBitMask(rs);
+#endif
 
 }
 

--- a/Adafruit_SSD1351.cpp
+++ b/Adafruit_SSD1351.cpp
@@ -24,7 +24,7 @@
   #include <avr/pgmspace.h>
 #elif defined(ESP8266)
   #include <pgmspace.h>
-#elif defined(NRF51) || defined(NRF52) || defined(__RFduino__) || defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+#elif defined defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
   #include <avr/pgmspace.h>
 #endif
 #include "pins_arduino.h"
@@ -49,7 +49,7 @@ inline void Adafruit_SSD1351::spiwrite(uint8_t c) {
         return;
     }
 
-	#if !defined(NRF51) && !defined(NRF52) && !defined(__RFduino__) && !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
+	#if !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
 
     int8_t i;
     
@@ -77,13 +77,13 @@ inline void Adafruit_SSD1351::spiwrite(uint8_t c) {
 
 
 void Adafruit_SSD1351::writeCommand(uint8_t c) {
-	#if defined(NRF51) || defined(NRF52) || defined(__RFduino__) || defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+#if defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
 	digitalWrite(_rs, LOW);
 	#else
 	*rsport &= ~ rspinmask;
 	#endif
     
-	#if defined(NRF51) || defined(NRF52) || defined(__RFduino__) || defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+#if defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
 	digitalWrite(_cs, LOW);
 	#else
 	*csport &= ~ cspinmask;
@@ -93,7 +93,7 @@ void Adafruit_SSD1351::writeCommand(uint8_t c) {
     //Serial.print("C ");
     spiwrite(c);
     
-	#if defined(NRF51) || defined(NRF52) || defined(__RFduino__) || defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+#if defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
 	digitalWrite(_cs, HIGH);
 	#else
 	*csport |= cspinmask;
@@ -102,13 +102,13 @@ void Adafruit_SSD1351::writeCommand(uint8_t c) {
 
 
 void Adafruit_SSD1351::writeData(uint8_t c) {
-	#if defined(NRF51) || defined(NRF52) || defined(__RFduino__) || defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+#if defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
     digitalWrite(_rs, HIGH);
 	#else
     *rsport |= rspinmask;
     #endif
 	
-	#if defined(NRF51) || defined(NRF52) || defined(__RFduino__) || defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+#if defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
 	digitalWrite(_cs, LOW);
 	#else
     *csport &= ~ cspinmask;
@@ -118,7 +118,7 @@ void Adafruit_SSD1351::writeData(uint8_t c) {
 //    Serial.print("D ");
     spiwrite(c);
     
-	#if defined(NRF51) || defined(NRF52) || defined(__RFduino__) || defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+#if defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
 	digitalWrite(_cs, HIGH);
 	#else
     *csport |= cspinmask;
@@ -361,7 +361,7 @@ void Adafruit_SSD1351::drawPixel(int16_t x, int16_t y, uint16_t color)
   goTo(x, y);
   
   // setup for data
-	#if defined(NRF51) || defined(NRF52) || defined(__RFduino__) || defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+#if defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
 	digitalWrite(_cs, LOW);
 	digitalWrite(_rs, HIGH);
 	#else
@@ -372,7 +372,7 @@ void Adafruit_SSD1351::drawPixel(int16_t x, int16_t y, uint16_t color)
   spiwrite(color >> 8);    
   spiwrite(color);
   
-  	#if defined(NRF51) || defined(NRF52) || defined(__RFduino__) || defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+  #if defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
 	digitalWrite(_cs, HIGH);
 	#else
 	*csport |= cspinmask;
@@ -488,7 +488,7 @@ void  Adafruit_SSD1351::invert(boolean v) {
  }
 
 /********************************* low level pin initialization */
-#if !defined(NRF51) && !defined(NRF52) && !defined(__RFduino__) && !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
+#if !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
 Adafruit_SSD1351::Adafruit_SSD1351(uint8_t cs, uint8_t rs, uint8_t sid, uint8_t sclk, uint8_t rst) : Adafruit_GFX(SSD1351WIDTH, SSD1351HEIGHT) {
     _cs = cs;
     _rs = rs;
@@ -517,7 +517,7 @@ Adafruit_SSD1351::Adafruit_SSD1351(uint8_t cs, uint8_t rs,  uint8_t rst) : Adafr
     _sid = 0;
     _sclk = 0;
     _rst = rst;
-#if !defined(NRF51) && !defined(NRF52) && !defined(__RFduino__) && !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
+#if !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
     csport      = portOutputRegister(digitalPinToPort(cs));
     cspinmask   = digitalPinToBitMask(cs);
     rsport      = portOutputRegister(digitalPinToPort(rs));

--- a/Adafruit_SSD1351.cpp
+++ b/Adafruit_SSD1351.cpp
@@ -24,9 +24,10 @@
   #include <avr/pgmspace.h>
 #elif defined(ESP8266)
   #include <pgmspace.h>
-#elif defined defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+#elif defined(ARDUINO_NRF52_PRIMO_CORE) || defined(ARDUINO_NRF52_PRIMO)
   #include <avr/pgmspace.h>
 #endif
+
 #include "pins_arduino.h"
 #include "wiring_private.h"
 #include <SPI.h>
@@ -49,7 +50,7 @@ inline void Adafruit_SSD1351::spiwrite(uint8_t c) {
         return;
     }
 
-	#if !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
+	#if !defined(ARDUINO_NRF52_PRIMO_CORE) && !defined(ARDUINO_NRF52_PRIMO)
 
     int8_t i;
     
@@ -77,23 +78,22 @@ inline void Adafruit_SSD1351::spiwrite(uint8_t c) {
 
 
 void Adafruit_SSD1351::writeCommand(uint8_t c) {
-#if defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+	#if defined(ARDUINO_NRF52_PRIMO_CORE) || defined(ARDUINO_NRF52_PRIMO)
 	digitalWrite(_rs, LOW);
 	#else
 	*rsport &= ~ rspinmask;
 	#endif
     
-#if defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+	#if defined(ARDUINO_NRF52_PRIMO_CORE) || defined(ARDUINO_NRF52_PRIMO)
 	digitalWrite(_cs, LOW);
 	#else
 	*csport &= ~ cspinmask;
 	#endif
-    //digitalWrite(_cs, LOW);
     
     //Serial.print("C ");
     spiwrite(c);
     
-#if defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+	#if defined(ARDUINO_NRF52_PRIMO_CORE) || defined(ARDUINO_NRF52_PRIMO)
 	digitalWrite(_cs, HIGH);
 	#else
 	*csport |= cspinmask;
@@ -102,13 +102,13 @@ void Adafruit_SSD1351::writeCommand(uint8_t c) {
 
 
 void Adafruit_SSD1351::writeData(uint8_t c) {
-#if defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+	#if defined(ARDUINO_NRF52_PRIMO_CORE) || defined(ARDUINO_NRF52_PRIMO)
     digitalWrite(_rs, HIGH);
 	#else
     *rsport |= rspinmask;
     #endif
 	
-#if defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+	#if defined(ARDUINO_NRF52_PRIMO_CORE) || defined(ARDUINO_NRF52_PRIMO)
 	digitalWrite(_cs, LOW);
 	#else
     *csport &= ~ cspinmask;
@@ -118,7 +118,7 @@ void Adafruit_SSD1351::writeData(uint8_t c) {
 //    Serial.print("D ");
     spiwrite(c);
     
-#if defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+	#if defined(ARDUINO_NRF52_PRIMO_CORE) || defined(ARDUINO_NRF52_PRIMO)
 	digitalWrite(_cs, HIGH);
 	#else
     *csport |= cspinmask;
@@ -361,7 +361,7 @@ void Adafruit_SSD1351::drawPixel(int16_t x, int16_t y, uint16_t color)
   goTo(x, y);
   
   // setup for data
-#if defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+	#if defined(ARDUINO_NRF52_PRIMO_CORE) || defined(ARDUINO_NRF52_PRIMO)
 	digitalWrite(_cs, LOW);
 	digitalWrite(_rs, HIGH);
 	#else
@@ -372,7 +372,7 @@ void Adafruit_SSD1351::drawPixel(int16_t x, int16_t y, uint16_t color)
   spiwrite(color >> 8);    
   spiwrite(color);
   
-  #if defined(NRF52_PRIMO_CORE) || defined(NRF52_PRIMO)
+	#if defined(ARDUINO_NRF52_PRIMO_CORE) || defined(ARDUINO_NRF52_PRIMO)
 	digitalWrite(_cs, HIGH);
 	#else
 	*csport |= cspinmask;
@@ -488,7 +488,7 @@ void  Adafruit_SSD1351::invert(boolean v) {
  }
 
 /********************************* low level pin initialization */
-#if !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
+#if !defined(ARDUINO_NRF52_PRIMO_CORE) && !defined(ARDUINO_NRF52_PRIMO)
 Adafruit_SSD1351::Adafruit_SSD1351(uint8_t cs, uint8_t rs, uint8_t sid, uint8_t sclk, uint8_t rst) : Adafruit_GFX(SSD1351WIDTH, SSD1351HEIGHT) {
     _cs = cs;
     _rs = rs;
@@ -517,7 +517,7 @@ Adafruit_SSD1351::Adafruit_SSD1351(uint8_t cs, uint8_t rs,  uint8_t rst) : Adafr
     _sid = 0;
     _sclk = 0;
     _rst = rst;
-#if !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
+#if !defined(ARDUINO_NRF52_PRIMO_CORE) && !defined(ARDUINO_NRF52_PRIMO)
     csport      = portOutputRegister(digitalPinToPort(cs));
     cspinmask   = digitalPinToBitMask(cs);
     rsport      = portOutputRegister(digitalPinToPort(rs));

--- a/Adafruit_SSD1351.h
+++ b/Adafruit_SSD1351.h
@@ -36,7 +36,7 @@
 //#elif defined (ESP8266)
 //    typedef volatile uint32_t PortReg;
 //    typedef uint32_t PortMask;
-#else
+#elseif !defined(NRF51) && !defined(NRF52) && !defined(__RFduino__) && !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
     typedef volatile uint8_t PortReg;
     typedef uint8_t PortMask;
 #endif
@@ -89,7 +89,9 @@
 
 class Adafruit_SSD1351  : public virtual Adafruit_GFX {
  public:
+ #if !defined(NRF51) && !defined(NRF52) && !defined(__RFduino__) && !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
   Adafruit_SSD1351(uint8_t CS, uint8_t RS, uint8_t SID, uint8_t SCLK, uint8_t RST);
+  #elseif
   Adafruit_SSD1351(uint8_t CS, uint8_t RS, uint8_t RST);
 
   uint16_t Color565(uint8_t r, uint8_t g, uint8_t b);
@@ -124,9 +126,10 @@ class Adafruit_SSD1351  : public virtual Adafruit_GFX {
   void rawFillRect(uint16_t x, uint16_t y, uint16_t w, uint16_t h, uint16_t fillcolor);
   void rawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
   void rawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
-
+	#if !defined(NRF51) && !defined(NRF52) && !defined(__RFduino__) && !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
   PortReg *csport, *rsport, *sidport, *sclkport;
   PortMask cspinmask, rspinmask, sidpinmask, sclkpinmask;
+  #elseif
   uint8_t _cs, _rs, _rst, _sid, _sclk;
 };
 

--- a/Adafruit_SSD1351.h
+++ b/Adafruit_SSD1351.h
@@ -36,7 +36,7 @@
 //#elif defined (ESP8266)
 //    typedef volatile uint32_t PortReg;
 //    typedef uint32_t PortMask;
-#elseif !defined(NRF51) && !defined(NRF52) && !defined(__RFduino__) && !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
+#elseif !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
     typedef volatile uint8_t PortReg;
     typedef uint8_t PortMask;
 #endif
@@ -89,7 +89,7 @@
 
 class Adafruit_SSD1351  : public virtual Adafruit_GFX {
  public:
- #if !defined(NRF51) && !defined(NRF52) && !defined(__RFduino__) && !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
+ #if !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
   Adafruit_SSD1351(uint8_t CS, uint8_t RS, uint8_t SID, uint8_t SCLK, uint8_t RST);
   #elseif
   Adafruit_SSD1351(uint8_t CS, uint8_t RS, uint8_t RST);
@@ -126,10 +126,10 @@ class Adafruit_SSD1351  : public virtual Adafruit_GFX {
   void rawFillRect(uint16_t x, uint16_t y, uint16_t w, uint16_t h, uint16_t fillcolor);
   void rawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
   void rawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
-	#if !defined(NRF51) && !defined(NRF52) && !defined(__RFduino__) && !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
+  #if !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
   PortReg *csport, *rsport, *sidport, *sclkport;
   PortMask cspinmask, rspinmask, sidpinmask, sclkpinmask;
-  #elseif
+  #elseif 
   uint8_t _cs, _rs, _rst, _sid, _sclk;
 };
 

--- a/Adafruit_SSD1351.h
+++ b/Adafruit_SSD1351.h
@@ -18,6 +18,7 @@
 #ifndef SSD1351_H
 #define SSD1351_H
 
+
 #define SSD1351WIDTH 128
 #define SSD1351HEIGHT 128  // SET THIS TO 96 FOR 1.27"!
 
@@ -36,7 +37,7 @@
 //#elif defined (ESP8266)
 //    typedef volatile uint32_t PortReg;
 //    typedef uint32_t PortMask;
-#elseif !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
+#elif !defined(ARDUINO_NRF52_PRIMO_CORE) && !defined(ARDUINO_NRF52_PRIMO)
     typedef volatile uint8_t PortReg;
     typedef uint8_t PortMask;
 #endif
@@ -89,9 +90,9 @@
 
 class Adafruit_SSD1351  : public virtual Adafruit_GFX {
  public:
- #if !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
+ #if !defined(ARDUINO_NRF52_PRIMO_CORE) && !defined(ARDUINO_NRF52_PRIMO)
   Adafruit_SSD1351(uint8_t CS, uint8_t RS, uint8_t SID, uint8_t SCLK, uint8_t RST);
-  #elseif
+  #endif
   Adafruit_SSD1351(uint8_t CS, uint8_t RS, uint8_t RST);
 
   uint16_t Color565(uint8_t r, uint8_t g, uint8_t b);
@@ -126,10 +127,10 @@ class Adafruit_SSD1351  : public virtual Adafruit_GFX {
   void rawFillRect(uint16_t x, uint16_t y, uint16_t w, uint16_t h, uint16_t fillcolor);
   void rawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
   void rawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
-  #if !defined(NRF52_PRIMO_CORE) && !defined(NRF52_PRIMO)
+  #if !defined(ARDUINO_NRF52_PRIMO_CORE) && !defined(ARDUINO_NRF52_PRIMO)
   PortReg *csport, *rsport, *sidport, *sclkport;
   PortMask cspinmask, rspinmask, sidpinmask, sclkpinmask;
-  #elseif 
+  #endif 
   uint8_t _cs, _rs, _rst, _sid, _sclk;
 };
 

--- a/examples/bmp/bmp.ino
+++ b/examples/bmp/bmp.ino
@@ -31,8 +31,8 @@
 
 
 // If we are using the hardware SPI interface, these are the pins (for future ref)
-#define sclk 13
-#define mosi 11
+//#define sclk 13
+//#define mosi 11
 #define cs   5
 #define rst  6
 #define dc   4

--- a/examples/test/test.ino
+++ b/examples/test/test.ino
@@ -25,8 +25,8 @@
  ****************************************************/
 
 // You can use any (4 or) 5 pins 
-#define sclk 2
-#define mosi 3
+//#define sclk 2
+//#define mosi 3
 #define dc   4
 #define cs   5
 #define rst  6
@@ -46,13 +46,14 @@
 #include <SPI.h>
 
 // Option 1: use any pins but a little slower
-Adafruit_SSD1351 tft = Adafruit_SSD1351(cs, dc, mosi, sclk, rst);  
+// It can't be used with Arduino Primo / Primo Core
+// Adafruit_SSD1351 tft = Adafruit_SSD1351(cs, dc, mosi, sclk, rst);  
 
 // Option 2: must use the hardware SPI pins 
 // (for UNO thats sclk = 13 and sid = 11) and pin 10 must be 
 // an output. This is much faster - also required if you want
 // to use the microSD card (see the image drawing example)
-//Adafruit_SSD1351 tft = Adafruit_SSD1351(cs, dc, rst);
+Adafruit_SSD1351 tft = Adafruit_SSD1351(cs, dc, rst);
 
 float p = 3.1415926;
 


### PR DESCRIPTION
**Added Arduino Primo (NRF52832 based board) support**
It uses DigitalWrite methods because the high complexity of port register manipulation on arm m4.
On the other boards it remains the same of the old version. Because of the high complexity of GPIO handling, software SPI is not available (only with Arduino Primo board).
The selection of the board is made using preprocessor directives, checking which board is selected.

Tested on Arduino Primo and Uno.

I hope that could be useful to all
