### PR TITLE
Fixed True SPI for Arduino Due

### DIFF
--- a/Adafruit_SSD1351.cpp
+++ b/Adafruit_SSD1351.cpp
@@ -44,6 +44,8 @@
 #define SPI_DEFAULT_FREQ 12000000 ///< M4 SPI default frequency
 #elif defined(ESP8266) || defined(ARDUINO_MAXIM)
 #define SPI_DEFAULT_FREQ 16000000 ///< ESP8266 SPI default frequency
+#elif defined(__SAM3X8E__)
+#define SPI_DEFAULT_FREQ 20000000 ///< SAM3X (ARDUINO DUE) SPI default frequency
 #elif defined(ESP32)
 #define SPI_DEFAULT_FREQ 24000000 ///< ESP32 SPI default frequency
 #elif defined(RASPI)
@@ -112,6 +114,8 @@ Adafruit_SSD1351::Adafruit_SSD1351(uint16_t width, uint16_t height,
                                    int8_t rst_pin)
     :
 #if defined(ESP8266)
+      Adafruit_SPITFT(width, height, cs_pin, dc_pin, rst_pin) {
+#elif defined(__SAM3X8E__)
       Adafruit_SPITFT(width, height, cs_pin, dc_pin, rst_pin) {
 #else
       Adafruit_SPITFT(width, height, spi, cs_pin, dc_pin, rst_pin){


### PR DESCRIPTION
Added a definition for the SPI frequency of the arduino due


- I have added a macro definition for the sam3x8e chip (Arduino Due) in the frequency and another macro definition of the constructor of true SPI

- The frequency value i used in the definition is highest frequency that i was able to test stably with my one (and only) Arduino Due. I have also tested it with a custom board board that uses the same sam3x8e chip. I have also added a true SPI constructor definition for the sam3x8e chip that is identical to the ESP8266. This addition is an improvement to the default constructor and improves the "tft.fillRect(0, 0, 128, 128, BLACK);" by 1ms

- True SPI with the given example "test.ino" does not work. After adding the definition it should function normonally on the Arduino Due and board that uses the sam3x8e chip


