### PR TITLE
Slow down SPI for the ESP32, for stability

### DIFF
--- a/Adafruit_SSD1351.cpp
+++ b/Adafruit_SSD1351.cpp
@@ -49,7 +49,7 @@
 #elif defined(__SAM3X8E__)
 #define SPI_DEFAULT_FREQ 20000000 ///< SAM3X (ARDUINO DUE) SPI default frequency
 #elif defined(ESP32)
-#define SPI_DEFAULT_FREQ 24000000 ///< ESP32 SPI default frequency
+#define SPI_DEFAULT_FREQ 16000000 ///< ESP32 SPI default frequency
 #elif defined(RASPI)
 #define SPI_DEFAULT_FREQ 24000000 ///< RASPI SPI default frequency
 #else


### PR DESCRIPTION
This fixes an issue as noted in https://forums.adafruit.com/viewtopic.php?f=47&t=170293 where code running on the Huzzah32 is crashing the OLED.