### PR TITLE
Added Adafruit BusIO dependancy

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Adafruit library for the 1.27" and 1.5" color OLEDs in the shop
 category=Display
 url=https://github.com/adafruit/Adafruit-SSD1351-library
 architectures=*
-depends=Adafruit ILI9341, Adafruit GFX Library
+depends=Adafruit ILI9341, Adafruit GFX Library, Adafruit BusIO 


### PR DESCRIPTION
This PR fixes the issue related to the missing header file:
fatal error: Adafruit_I2CDevice.h: No such file or directory

This fix is also given here https://github.com/adafruit/Adafruit_VEML6075/issues/5 for a similar library.