### PR TITLE
Corrected default SPI frequency for NRF52840

### DIFF
--- a/Adafruit_SSD1351.cpp
+++ b/Adafruit_SSD1351.cpp
@@ -52,6 +52,8 @@
 #define SPI_DEFAULT_FREQ 16000000 ///< ESP32 SPI default frequency
 #elif defined(RASPI)
 #define SPI_DEFAULT_FREQ 24000000 ///< RASPI SPI default frequency
+#elif defined(ARDUINO_NRF52840_FEATHER)
+#define SPI_DEFAULT_FREQ 16000000 ///< NRF52840 SPI default frequency
 #else
 #define SPI_DEFAULT_FREQ 24000000 ///< SPI default frequency
 #endif


### PR DESCRIPTION
Updated the default SPI frequency section of Adafruit_SSD1351.cpp to include a new default frequency for the NRF52840 devices. 

No known limitations.

Originally could not get the 1.5" OLED working on my Adafruit NRF52840 Express board. It would work with software SPI and would work under CircuitPython. After a number of tests I discovered that the default SPI frequency was being set too high and would cause the display not to function. After making this change my 1.5" OLED works properly with my Adafruit NRF52840 Express board.