### PR TITLE
Support for building as an ESP-IDF component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Doxyfile*
 doxygen_sqlite3.db
 html
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Adafruit SSD1351 Library
+# https://github.com/adafruit/Adafruit-SSD1351-Library
+# BSD License
+
+cmake_minimum_required(VERSION 3.5)
+
+idf_component_register(SRCS "Adafruit_SSD1351.cpp"
+                       INCLUDE_DIRS "."
+                       REQUIRES arduino Adafruit-GFX-Library)
+
+project(Adafruit-SSD1351-library)


### PR DESCRIPTION
This PR adds the required `CMakeLists.txt` file to enable building as an ESP-IDF component (e.g. in `components/Adafruit-SSD1351-library`)

Similar [PR from Adafruit-GFX-Library](https://github.com/adafruit/Adafruit-GFX-Library/pull/376/files).
